### PR TITLE
feat: MySQL docker compose 작성 및 연동, User 엔티티 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,11 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'mysql:mysql-connector-java:8.0.32'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,9 @@
+services:
+  mysql:
+    image: bitnami/mysql:latest
+    container_name: mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=mydatabase
+    ports:
+      - '3306:3306'

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/domain/enums/UserRoleEnum.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/domain/enums/UserRoleEnum.java
@@ -1,0 +1,5 @@
+package com.github.kimjinmyeong.spring_jwt_auth.domain.enums;
+
+public enum UserRoleEnum {
+    MASTER, USER
+}

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/domain/model/User.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/domain/model/User.java
@@ -1,0 +1,34 @@
+package com.github.kimjinmyeong.spring_jwt_auth.domain.model;
+
+import com.github.kimjinmyeong.spring_jwt_auth.domain.enums.UserRoleEnum;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Set;
+
+@Entity(name = "users")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @ElementCollection(targetClass = UserRoleEnum.class, fetch = FetchType.EAGER)
+    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "id"))
+    @Enumerated(EnumType.STRING)
+    private Set<UserRoleEnum> roles;
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/mydatabase
+    username: root
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    database-platform: org.hibernate.dialect.MySQLDialect
+
+jwt:
+  secret:
+    expiration-time: 360000
+    key: wNvgwcA58v1tl6qymQzkMYuoBNagahQnl04ebxQLlxWlotT8qEhGnJsXRgGY7Q38

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=spring-jwt-auth

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  application:
+    name: spring-jwt-auth
+  profiles:
+    active: dev


### PR DESCRIPTION
이 PR 에서는 다음을 수행하였습니다.

- MySQL docker compose 작성
- application 프로필 dev로 분리
- jpa, mysql, jwt 의존성 추가
- User 엔티티 구현
- UserRoleEnum 추가 (MASTER, USER)
