### PR TITLE
feat: SecurityConfig, JWT 관련 설정 구현

### DIFF
--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/application/service/dto/UserPrincipalDto.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/application/service/dto/UserPrincipalDto.java
@@ -1,0 +1,28 @@
+package com.github.kimjinmyeong.spring_jwt_auth.application.service.dto;
+
+import com.github.kimjinmyeong.spring_jwt_auth.domain.enums.UserRoleEnum;
+import com.github.kimjinmyeong.spring_jwt_auth.domain.model.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+@Builder
+public class UserPrincipalDto {
+
+    private String username;
+
+    private String password;
+
+    private Set<UserRoleEnum> roles;
+
+    public static UserPrincipalDto fromEntity(User user) {
+        return UserPrincipalDto.builder()
+                .username(user.getUsername())
+                .password(user.getPassword())
+                .roles(user.getRoles())
+                .build();
+    }
+}
+

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/domain/repository/UserRepository.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/domain/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.github.kimjinmyeong.spring_jwt_auth.domain.repository;
+
+import com.github.kimjinmyeong.spring_jwt_auth.domain.model.User;
+
+import java.util.Optional;
+
+public interface UserRepository {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/repository/UserJpaRepository.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/repository/UserJpaRepository.java
@@ -1,0 +1,11 @@
+package com.github.kimjinmyeong.spring_jwt_auth.infrastructure.repository;
+
+import com.github.kimjinmyeong.spring_jwt_auth.domain.model.User;
+import com.github.kimjinmyeong.spring_jwt_auth.domain.repository.UserRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserJpaRepository extends UserRepository, JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,63 @@
+package com.github.kimjinmyeong.spring_jwt_auth.infrastructure.security;
+
+import com.github.kimjinmyeong.spring_jwt_auth.infrastructure.security.jwt.JwtAuthorizationFilter;
+import com.github.kimjinmyeong.spring_jwt_auth.infrastructure.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+
+    private final UserDetailsService userDetailsService;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        // Disable CSRF protection
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        // Set up authorization rules
+        http.authorizeHttpRequests(authorize ->
+                authorize.requestMatchers("/signup", "/sign")
+                        .permitAll()
+                        .anyRequest().authenticated());
+
+        // Configure session management to never create sessions
+        http.sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.NEVER)
+        );
+
+        // Add the JWT authorization filter before the UsernamePasswordAuthenticationFilter
+        http.addFilterBefore(new JwtAuthorizationFilter(jwtUtil, userDetailsService),
+                UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+}

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/UserDetailsImpl.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/UserDetailsImpl.java
@@ -1,0 +1,36 @@
+package com.github.kimjinmyeong.spring_jwt_auth.infrastructure.security;
+
+import com.github.kimjinmyeong.spring_jwt_auth.application.service.dto.UserPrincipalDto;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class UserDetailsImpl implements UserDetails {
+
+    private final UserPrincipalDto userPrincipalDto;
+
+    public UserDetailsImpl(UserPrincipalDto userPrincipalDto) {
+        this.userPrincipalDto = userPrincipalDto;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return userPrincipalDto.getRoles().stream()
+                .map(role -> new SimpleGrantedAuthority(role.name()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return userPrincipalDto.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return userPrincipalDto.getUsername();
+    }
+
+}

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.github.kimjinmyeong.spring_jwt_auth.infrastructure.security;
+
+import com.github.kimjinmyeong.spring_jwt_auth.application.service.dto.UserPrincipalDto;
+import com.github.kimjinmyeong.spring_jwt_auth.domain.model.User;
+import com.github.kimjinmyeong.spring_jwt_auth.domain.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new UsernameNotFoundException(username));
+        return new UserDetailsImpl(UserPrincipalDto.fromEntity(user));
+    }
+}

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/jwt/JwtAuthorizationFilter.java
@@ -1,0 +1,41 @@
+package com.github.kimjinmyeong.spring_jwt_auth.infrastructure.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = jwtUtil.resolveToken(request);
+
+        if (token != null && jwtUtil.validateToken(token)) {
+            String username = jwtUtil.getUsernameFromToken(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/jwt/JwtUtil.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/jwt/JwtUtil.java
@@ -1,0 +1,88 @@
+package com.github.kimjinmyeong.spring_jwt_auth.infrastructure.security.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.*;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    public final String AUTHORIZATION_HEADER = "Authorization";
+
+    public final String BEARER_PREFIX = "Bearer ";
+
+    @Value("${jwt.secret.expiration-time}")
+    private long EXPIRATION_TIME;
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    private Key key;
+
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String createToken(String username, List<SimpleGrantedAuthority> roles) {
+        Date date = new Date();
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("roles", roles);
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setClaims(claims)
+                        .setSubject(username)
+                        .setExpiration(new Date(date.getTime() + EXPIRATION_TIME))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken)) {
+            String decodedToken = URLDecoder.decode(bearerToken, StandardCharsets.UTF_8);
+            if (decodedToken.startsWith(BEARER_PREFIX)) {
+                return decodedToken.substring(7);
+            }
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
+            log.error("Invalid JWT signature.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims is empty.");
+        }
+        return false;
+    }
+
+    public String getUsernameFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject();
+    }
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,5 +12,5 @@ spring:
 
 jwt:
   secret:
-    expiration-time: 360000
+    expiration-time-ms: 3600000
     key: wNvgwcA58v1tl6qymQzkMYuoBNagahQnl04ebxQLlxWlotT8qEhGnJsXRgGY7Q38


### PR DESCRIPTION
이 PR에서는 Spring Security 설정과 JWT 설정을 구현합니다.

- SpringSecurity 추가

### JWT 설정 추가

- JWT Payload에는 username과 roles가 들어갑니다.
- 만료 시간은 1시간 입니다.

**JWT Header 예시**
```json
{
  "alg": "HS256",
  "typ": "JWT"
}
```
**JWT Payload 예시**
```json
{
  "sub": "user123",
  "roles": ["ROLE_USER", "ROLE_ADMIN"],
  "iat": 1697123456,
  "exp": 1697127056
}
```