### PR TITLE
feat: 인가 테스트용 메서드 구현 및 Security 커스텀 Exception 추가

### DIFF
--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/application/service/AuthService.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/application/service/AuthService.java
@@ -11,6 +11,7 @@ import com.github.kimjinmyeong.spring_jwt_auth.exception.ErrorMessage;
 import com.github.kimjinmyeong.spring_jwt_auth.exception.UnAuthorizationException;
 import com.github.kimjinmyeong.spring_jwt_auth.presentation.dto.LoginRequestDto;
 import com.github.kimjinmyeong.spring_jwt_auth.presentation.dto.SignupRequestDto;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 
+import static com.github.kimjinmyeong.spring_jwt_auth.application.util.JwtUtil.BEARER_PREFIX;
 import static com.github.kimjinmyeong.spring_jwt_auth.infrastructure.security.UserDetailsImpl.ROLE_PREFIX;
 
 @Slf4j
@@ -64,7 +66,7 @@ public class AuthService {
     }
 
     @Transactional(readOnly = true)
-    public LoginResponseDto login(LoginRequestDto request) {
+    public LoginResponseDto login(LoginRequestDto request, HttpServletResponse response) {
         log.info("Attempting to log in user: {}", request.getUsername());
 
         User user = userRepository.findByUsername(request.getUsername())
@@ -81,6 +83,8 @@ public class AuthService {
         String token = jwtUtil.createToken(user.getUsername(), user.getRoles());
         log.info("User logged in successfully: {}, token issued", user.getUsername());
 
+        response.setHeader("Authorization", BEARER_PREFIX + token);
         return new LoginResponseDto(token);
     }
+
 }

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/application/startup/InitData.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/application/startup/InitData.java
@@ -1,0 +1,33 @@
+package com.github.kimjinmyeong.spring_jwt_auth.application.startup;
+
+import com.github.kimjinmyeong.spring_jwt_auth.domain.enums.UserRoleEnum;
+import com.github.kimjinmyeong.spring_jwt_auth.domain.model.User;
+import com.github.kimjinmyeong.spring_jwt_auth.domain.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Slf4j
+@Configuration
+public class InitData {
+    @Bean
+    public CommandLineRunner loadData(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        return args -> {
+            if (userRepository.findByUsername("admin").isEmpty()) {
+                User masterUser = User.builder()
+                        .username("admin")
+                        .password(passwordEncoder.encode("adminpassword"))
+                        .nickname("MasterAdmin")
+                        .roles(new HashSet<>(Set.of(UserRoleEnum.MASTER)))
+                        .build();
+                userRepository.save(masterUser);
+                log.info("MASTER user created with username: 'admin' and default password.");
+            }
+        };
+    }
+}

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/application/util/JwtUtil.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/application/util/JwtUtil.java
@@ -19,9 +19,9 @@ import java.util.stream.Collectors;
 @Component
 public class JwtUtil {
 
-    public final String AUTHORIZATION_HEADER = "Authorization";
+    public final static String AUTHORIZATION_HEADER = "Authorization";
 
-    public final String BEARER_PREFIX = "Bearer ";
+    public final static String BEARER_PREFIX = "Bearer ";
 
     @Value("${jwt.secret.expiration-time-ms}")
     private long expirationTimeMs;

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/openapi/OpenApiConfig.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/openapi/OpenApiConfig.java
@@ -1,0 +1,22 @@
+package com.github.kimjinmyeong.spring_jwt_auth.infrastructure.openapi;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "API Documentation", version = "1.0", description = "API Documentation with JWT Bearer Authentication"),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+public class OpenApiConfig {
+}

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,21 @@
+package com.github.kimjinmyeong.spring_jwt_auth.infrastructure.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"Access Denied. Insufficient permissions.\"}");
+    }
+}

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.github.kimjinmyeong.spring_jwt_auth.infrastructure.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"Unauthorized access. Please log in.\"}");
+    }
+}

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/infrastructure/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -18,12 +19,17 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
 
     private final UserDetailsService userDetailsService;
+
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -40,6 +46,13 @@ public class SecurityConfig {
                                 "/docs")
                         .permitAll()
                         .anyRequest().authenticated());
+
+        // Configure custom exception handling
+        http.exceptionHandling(exceptionHandling ->
+                exceptionHandling
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler)
+        );
 
         // Configure session management to never create sessions
         http.sessionManagement(session -> session

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/presentation/controller/AuthController.java
@@ -7,9 +7,12 @@ import com.github.kimjinmyeong.spring_jwt_auth.presentation.dto.LoginRequestDto;
 import com.github.kimjinmyeong.spring_jwt_auth.presentation.dto.SignupRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,9 +36,24 @@ public class AuthController {
     @PostMapping("/sign")
     public ResponseEntity<LoginResponseDto> login(
             @Parameter(description = "Login request data", required = true)
-            @Valid @RequestBody LoginRequestDto loginRequest) {
-        LoginResponseDto loginResponse = authService.login(loginRequest);
+            @Valid @RequestBody LoginRequestDto loginRequest,
+            HttpServletResponse response) {
+        LoginResponseDto loginResponse = authService.login(loginRequest, response);
         return ResponseEntity.ok(loginResponse);
+    }
+
+    @Operation(summary = "Admin Only Access", description = "Access restricted to users with MASTER role.")
+    @PreAuthorize("hasRole('MASTER')")
+    @GetMapping("/admin")
+    public ResponseEntity<String> adminAccess() {
+        return ResponseEntity.ok("Access granted to MASTER role.");
+    }
+
+    @Operation(summary = "User Only Access", description = "Access restricted to users with USER role.")
+    @PreAuthorize("hasRole('USER')")
+    @GetMapping("/user")
+    public ResponseEntity<String> userAccess() {
+        return ResponseEntity.ok("Access granted to USER role.");
     }
 
 }


### PR DESCRIPTION
이 PR에서는 아래를 수행하였습니다,
- Spring Security에서 인증 실패 및 인가 실패 커스텀 Exception 구현
- 애플리케이션 시작 시 admin 계정 생성
- swagger ui에서 token 값을 header에 추가하도록 수정
- 로그인 성공 시 응답 헤더에 `Authorization: Bearer {token}`를 추가
