### PR TITLE
feat: H2 DB 의존성 추가 및 테스트 코드 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/presentation/dto/LoginRequestDto.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/presentation/dto/LoginRequestDto.java
@@ -2,9 +2,11 @@ package com.github.kimjinmyeong.spring_jwt_auth.presentation.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class LoginRequestDto {
 
     @NotBlank

--- a/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/presentation/dto/SignupRequestDto.java
+++ b/src/main/java/com/github/kimjinmyeong/spring_jwt_auth/presentation/dto/SignupRequestDto.java
@@ -2,9 +2,11 @@ package com.github.kimjinmyeong.spring_jwt_auth.presentation.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class SignupRequestDto {
 
     @NotBlank

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+logging:
+  level:
+    org.hibernate.sql: info
+
+jwt:
+  secret:
+    expiration-time-ms: 3600000
+    key: wNvgwcA58v1tl6qymQzkMYuoBNagahQnl04ebxQLlxWlotT8qEhGnJsXRgGY7Q38

--- a/src/test/java/com/github/kimjinmyeong/spring_jwt_auth/presentation/controller/AuthControllerTest.java
+++ b/src/test/java/com/github/kimjinmyeong/spring_jwt_auth/presentation/controller/AuthControllerTest.java
@@ -1,0 +1,123 @@
+package com.github.kimjinmyeong.spring_jwt_auth.presentation.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.kimjinmyeong.spring_jwt_auth.application.service.AuthService;
+import com.github.kimjinmyeong.spring_jwt_auth.presentation.dto.LoginRequestDto;
+import com.github.kimjinmyeong.spring_jwt_auth.presentation.dto.SignupRequestDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AuthService authService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testSignup_Success() throws Exception {
+        SignupRequestDto signupRequestDto = new SignupRequestDto("testuser", "password123", "testnickname");
+
+        mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(signupRequestDto))
+                        .with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testSignup_ValidationError() throws Exception {
+        SignupRequestDto signupRequestDto = new SignupRequestDto("", "password123", "testnickname");
+
+        mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(signupRequestDto))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testLogin_Success() throws Exception {
+        // First, sign up the user
+        SignupRequestDto signupRequestDto = new SignupRequestDto("testuser2", "password123", "testnickname2");
+        authService.signup(signupRequestDto);
+
+        LoginRequestDto loginRequestDto = new LoginRequestDto("testuser2", "password123");
+
+        mockMvc.perform(post("/sign")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequestDto))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").exists());
+    }
+
+    @Test
+    public void testLogin_InvalidCredentials() throws Exception {
+        LoginRequestDto loginRequestDto = new LoginRequestDto("nonexistentuser", "password123");
+
+        mockMvc.perform(post("/sign")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequestDto))
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "MASTER")
+    public void testAdminAccess_WithMasterRole() throws Exception {
+        mockMvc.perform(get("/admin"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Access granted to MASTER role."));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    public void testAdminAccess_WithUserRole() throws Exception {
+        mockMvc.perform(get("/admin"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    public void testUserAccess_WithUserRole() throws Exception {
+        mockMvc.perform(get("/user"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Access granted to USER role."));
+    }
+
+    @Test
+    @WithMockUser(roles = "MASTER")
+    public void testUserAccess_WithMasterRole() throws Exception {
+        mockMvc.perform(get("/user"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void testAdminAccess_WithoutAuthentication() throws Exception {
+        mockMvc.perform(get("/admin"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testUserAccess_WithoutAuthentication() throws Exception {
+        mockMvc.perform(get("/user"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
This PR resolves #7 .

- H2 DB를 테스트 데이터베이스로 사용하기 위해 의존성 추가 및 테스트용 프로필을 추가합니다.
- AuthController 통합 테스트를 구현합니다.